### PR TITLE
Fix: transcode coroutine didn't run if longer than 1 frame

### DIFF
--- a/Runtime/Scripts/KtxTexture.cs
+++ b/Runtime/Scripts/KtxTexture.cs
@@ -33,7 +33,9 @@ namespace KtxUnity {
                 orientation = ktx.orientation;
                 if(ktx.ktxClass==KtxClassId.ktxTexture2_c) {
                     if(ktx.needsTranscoding) {
-                        yield return Transcode(ktx,linear);
+                        var transcode = Transcode(ktx,linear);
+                        while (transcode.MoveNext())
+                            yield return null;
                     } else {
                         Debug.LogError("Only supercompressed KTX is supported");
                     }


### PR DESCRIPTION
Child coroutines can't be started this way; they need to be started with StartCoroutine or manually progressed from the parent coroutine.