### PR TITLE
Fix undefined error variable when building project

### DIFF
--- a/Runtime/Scripts/ErrorCode.cs
+++ b/Runtime/Scripts/ErrorCode.cs
@@ -46,7 +46,7 @@ namespace KtxUnity {
 #if DEBUG
             return $"No Error message for error {code.ToString()}";
 #else
-            return UnknownErrorMessage;
+            return k_UnknownErrorMessage;
 #endif
         }
     }


### PR DESCRIPTION
`UnknownErrorMessage` is undefined for release builds, switches to defined variable instead.