### PR TITLE
fix: Loading of native library on Linux

### DIFF
--- a/Runtime/Scripts/KtxNativeInstance.cs
+++ b/Runtime/Scripts/KtxNativeInstance.cs
@@ -25,7 +25,7 @@ namespace KtxUnity {
 
     public class KtxNativeInstance : IMetaData, ILevelInfo
     {
-#if UNITY_EDITOR_OSX || UNITY_WEBGL || UNITY_IOS
+#if UNITY_EDITOR_OSX || UNITY_WEBGL || (UNITY_IOS && !UNITY_EDITOR)
         public const string INTERFACE_DLL = "__Internal";
 #elif UNITY_ANDROID || UNITY_STANDALONE || UNITY_WSA || UNITY_EDITOR || PLATFORM_LUMIN
         public const string INTERFACE_DLL = "ktx_unity";


### PR DESCRIPTION
Loading the library on Linux with iOS build target failed without the additional check.

Closes: https://github.com/atteneder/KtxUnity/issues/59